### PR TITLE
PR: Add mention of exponentiation to list of supported arithmetic operators for "colour.SpectralPowerDistribution" class.

### DIFF
--- a/notebooks/colorimetry/spectrum.ipynb
+++ b/notebooks/colorimetry/spectrum.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:d49265b2a2cbbaa716b7a49a755504b7e7b09cdf057374d946eef0df4b92b760"
+  "signature": "sha256:6f8bb7e072d19c75b5df551066b8db4d4bb60936a5ca2f16adce8e099f3d545d"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -750,7 +750,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "The *colour.SpectralPowerDistribution* class also supports various arithmetic operations like *addition*, *subtraction*, *multiplication* or *division* with *numeric* and *array_like* variables or other *colour.SpectralPowerDistribution* class instances:"
+      "The *colour.SpectralPowerDistribution* class also supports various arithmetic operations like *addition*, *subtraction*, *multiplication*, *division* or *exponentiation* with *numeric* and *array_like* variables or other *colour.SpectralPowerDistribution* class instances:"
      ]
     },
     {


### PR DESCRIPTION
Added "exponentiation" to list of arithmetic operators for SpectralPowerDistribution as part of documentation for new **pow** magic method. Re-ran notebook without errors.
