### PR TITLE
Fix micrometre unit shorthand

### DIFF
--- a/notebooks/colorimetry/lefs.ipynb
+++ b/notebooks/colorimetry/lefs.ipynb
@@ -29,7 +29,7 @@
    "source": [
     "[Radiometry](http://en.wikipedia.org/wiki/Radiometry) is defined as the measurement of the quantities associated with optical radiation. <a name=\"back_reference_4\"></a><a href=\"#reference_4\">[4]</a>\n",
     "\n",
-    "Photometric quantities are weighted accordingly to human visual system spectral sensitivity within the wavelength range 360-780 nanometres (nm) while radiometric quantities represent unweighted absolute power within the wavelength range 0.01-1000 micrometres (mm).\n",
+    "Photometric quantities are weighted accordingly to human visual system spectral sensitivity within the wavelength range 360-780 nanometres ($nm$) while radiometric quantities represent unweighted absolute power within the wavelength range 0.01-1000 micrometres ($\\mu m$).\n",
     "\n",
     "Given the following terms and units table: <a name=\"back_reference_5\"></a><a href=\"#reference_5\">[5]</a>\n",
     "    \n",


### PR DESCRIPTION
Hello,

I listened to Thomas Mansencal's interview on Podcast.\_\_init\_\_('Python') and thought the project sounded really interesting. I'm looking forward to taking a closer look at it for some upcoming calibration work I'll be doing; I think it could turn out to be a valuable resource.

Anyway, I was exploring some of the documentation and noticed that _micrometre_ was was shortened to _mm_ instead of _μm_ in the Luminous Efficiency Functions notebook. As I'm in need of some experience with the workflow involved in contributing to open source projects, I've attached the trivial fix in this PR. The  _nm_ shorthand in the same paragraph has also been enclosed in the math environment for visual consistency with the other occurrences in the notebook.
